### PR TITLE
Tickless patch for openbsd current

### DIFF
--- a/share/man/man9/timeout.9
+++ b/share/man/man9/timeout.9
@@ -35,6 +35,9 @@
 .Nm timeout_add_nsec ,
 .Nm timeout_add_usec ,
 .Nm timeout_add_tv ,
+.Nm timeout_add_ts ,
+.Nm timeout_add_bt ,
+.Nm timeout_at_ts ,
 .Nm timeout_del ,
 .Nm timeout_del_barrier ,
 .Nm timeout_barrier ,
@@ -80,6 +83,8 @@
 .Fn timeout_add_usec "struct timeout *to" "int usec"
 .Ft int
 .Fn timeout_add_nsec "struct timeout *to" "int nsec"
+.Ft int
+.Fn timeout_at_ts "struct timeout *to" "clockid_t clock" "struct timespec *when"
 .Fn TIMEOUT_INITIALIZER "void (*fn)(void *)" "void *arg"
 .Fn TIMEOUT_INITIALIZER_FLAGS "void (*fn)(void *)" "void *arg" "int flags"
 .Sh DESCRIPTION
@@ -217,6 +222,20 @@ Those functions add a timeout whilst converting the time specified
 by the respective types.
 They also defer the timeout handler for at least one tick if called
 with a positive value.
+.Pp
+.Fn timeout_at_ts
+schedules
+.Fa to
+for execution no earlier than
+.Fa when ,
+an absolute time on the given
+.Fa clock .
+The
+.Fa clock
+may be either
+.Dv CLOCK_BOOTTIME
+or
+.Dv CLOCK_MONOTONIC .
 .Pp
 A timeout declaration can be initialised with the
 .Fn TIMEOUT_INITIALIZER

--- a/sys/dev/pci/drm/i915/gt/intel_engine_cs.c
+++ b/sys/dev/pci/drm/i915/gt/intel_engine_cs.c
@@ -1286,7 +1286,7 @@ static struct intel_timeline *get_timeline(struct i915_request *rq)
 
 static const char *repr_timer(const struct timeout *t)
 {
-	if (!READ_ONCE(t->to_time))
+	if (!(READ_ONCE(t->to_time.tv_sec) && READ_ONCE(t->to_time.tv_sec)))
 		return "inactive";
 
 	if (timer_pending(t))

--- a/sys/dev/pci/drm/i915/i915_utils.c
+++ b/sys/dev/pci/drm/i915/i915_utils.c
@@ -87,11 +87,12 @@ bool i915_error_injected(void)
 
 void cancel_timer(struct timeout *t)
 {
-	if (!READ_ONCE(t->to_time))
+	if (!(READ_ONCE(t->to_time.tv_sec) && READ_ONCE(t->to_time.tv_nsec)))
 		return;
 
 	del_timer(t);
-	WRITE_ONCE(t->to_time, 0);
+	WRITE_ONCE(t->to_time.tv_sec, 0);
+	WRITE_ONCE(t->to_time.tv_nsec, 0);
 }
 
 void set_timer_ms(struct timeout *t, unsigned long timeout)

--- a/sys/dev/pci/drm/i915/i915_utils.h
+++ b/sys/dev/pci/drm/i915/i915_utils.h
@@ -461,7 +461,7 @@ static inline bool timer_expired(const struct timeout *t)
 #ifdef __linux__
 	return READ_ONCE(t->expires) && !timer_pending(t);
 #else
-	return READ_ONCE(t->to_time) && !timer_pending(t);
+	return READ_ONCE(t->to_time.tv_sec) && READ_ONCE(t->to_time.tv_nsec) && !timer_pending(t);
 #endif
 }
 

--- a/sys/dev/pci/drm/scheduler/sched_main.c
+++ b/sys/dev/pci/drm/scheduler/sched_main.c
@@ -234,7 +234,7 @@ unsigned long drm_sched_suspend_timeout(struct drm_gpu_scheduler *sched)
 #ifdef __linux__
 	sched_timeout = sched->work_tdr.timer.expires;
 #else
-	sched_timeout = sched->work_tdr.to.to_time * hz;
+	sched_timeout = ((unsigned long)(sched->work_tdr.to.to_time.tv_sec*1000000) + (sched->work_tdr.to.to_time.tv_nsec/1000)) / hz;
 #endif
 
 	/*

--- a/sys/kern/kern_tc.c
+++ b/sys/kern/kern_tc.c
@@ -521,7 +521,7 @@ tc_setclock(const struct timespec *ts)
 	if (adj_ticks > 0) {
 		if (adj_ticks > INT_MAX)
 			adj_ticks = INT_MAX;
-		timeout_adjust_ticks(adj_ticks);
+		ticks += adj_ticks;
 	}
 #endif
 }

--- a/sys/kern/kern_timeout.c
+++ b/sys/kern/kern_timeout.c
@@ -61,34 +61,24 @@ struct timeoutstat tostat;		/* [T] statistics and totals */
 
 /*
  * Timeouts are kept in a hierarchical timing wheel. The to_time is the value
- * of the global variable "ticks" when the timeout should be called. There are
+ * of the system uptime clock when the timeout should be called. There are
  * four levels with 256 buckets each.
  */
-#define BUCKETS 1024
+#define WHEELCOUNT 4
 #define WHEELSIZE 256
 #define WHEELMASK 255
 #define WHEELBITS 8
+#define BUCKETS (WHEELCOUNT * WHEELSIZE)
 
 struct circq timeout_wheel[BUCKETS];	/* [T] Queues of timeouts */
 struct circq timeout_new;		/* [T] New, unscheduled timeouts */
 struct circq timeout_todo;		/* [T] Due or needs rescheduling */
 struct circq timeout_proc;		/* [T] Due + needs process context */
 
-#define MASKWHEEL(wheel, time) (((time) >> ((wheel)*WHEELBITS)) & WHEELMASK)
-
-#define BUCKET(rel, abs)						\
-    (timeout_wheel[							\
-	((rel) <= (1 << (2*WHEELBITS)))					\
-	    ? ((rel) <= (1 << WHEELBITS))				\
-		? MASKWHEEL(0, (abs))					\
-		: MASKWHEEL(1, (abs)) + WHEELSIZE			\
-	    : ((rel) <= (1 << (3*WHEELBITS)))				\
-		? MASKWHEEL(2, (abs)) + 2*WHEELSIZE			\
-		: MASKWHEEL(3, (abs)) + 3*WHEELSIZE])
-
-#define MOVEBUCKET(wheel, time)						\
-    CIRCQ_CONCAT(&timeout_todo,						\
-        &timeout_wheel[MASKWHEEL((wheel), (time)) + (wheel)*WHEELSIZE])
+time_t timeout_level_width[WHEELCOUNT];	/* [I] Wheel level width (seconds) */
+struct timespec tick_ts;		/* [I] Length of a tick (1/hz secs) */
+struct timespec timeout_lastscan;	/* [t] Uptime at last wheel scan */
+struct timespec timeout_late;		/* [t] Late if due prior to this */
 
 /*
  * Circular queue definitions.
@@ -158,6 +148,10 @@ struct lock_type timeout_spinlock_type = {
 void softclock(void *);
 void softclock_create_thread(void *);
 void softclock_thread(void *);
+int timeout_at_ts_locked(struct timeout *, clockid_t, const struct timespec *);
+unsigned int timeout_bucket(const struct timespec *, const struct timespec *);
+int timeout_clock_is_valid(clockid_t);
+unsigned int timeout_maskwheel(unsigned int, const struct timespec *);
 void timeout_proc_barrier(void *);
 
 /*
@@ -190,30 +184,24 @@ timeout_sync_leave(int needsproc)
 	WITNESS_UNLOCK(TIMEOUT_LOCK_OBJ(needsproc), 0);
 }
 
-/*
- * Some of the "math" in here is a bit tricky.
- *
- * We have to beware of wrapping ints.
- * We use the fact that any element added to the queue must be added with a
- * positive time. That means that any element `to' on the queue cannot be
- * scheduled to timeout further in time than INT_MAX, but to->to_time can
- * be positive or negative so comparing it with anything is dangerous.
- * The only way we can use the to->to_time value in any predictable way
- * is when we calculate how far in the future `to' will timeout -
- * "to->to_time - ticks". The result will always be positive for future
- * timeouts and 0 or negative for due timeouts.
- */
-
 void
 timeout_startup(void)
 {
-	int b;
+	unsigned int b, level;
 
 	CIRCQ_INIT(&timeout_new);
 	CIRCQ_INIT(&timeout_todo);
 	CIRCQ_INIT(&timeout_proc);
 	for (b = 0; b < nitems(timeout_wheel); b++)
 		CIRCQ_INIT(&timeout_wheel[b]);
+
+	for (level = 0; level < nitems(timeout_level_width); level++)
+		timeout_level_width[level] = 2 << (level * WHEELBITS);
+
+	tick_ts.tv_sec = 0;
+	tick_ts.tv_nsec = tick_nsec;
+	timespecclear(&timeout_lastscan);
+	timespecclear(&timeout_late);
 }
 
 void
@@ -242,6 +230,7 @@ timeout_set_flags(struct timeout *to, void (*fn)(void *), void *arg, int flags)
 	to->to_arg = arg;
 	to->to_process = NULL;
 	to->to_flags = flags | TIMEOUT_INITIALIZED;
+	timespecclear(&to->to_time);
 }
 
 void
@@ -253,39 +242,15 @@ timeout_set_proc(struct timeout *new, void (*fn)(void *), void *arg)
 int
 timeout_add(struct timeout *new, int to_ticks)
 {
-	int old_time;
-	int ret = 1;
+	struct timespec ts, when;
+	int ret;
 
-	KASSERT(ISSET(new->to_flags, TIMEOUT_INITIALIZED));
 	KASSERT(to_ticks >= 0);
+	NSEC_TO_TIMESPEC((uint64_t)to_ticks * tick_nsec, &ts);
 
 	mtx_enter(&timeout_mutex);
-
-	/* Initialize the time here, it won't change. */
-	old_time = new->to_time;
-	new->to_time = to_ticks + ticks;
-	CLR(new->to_flags, TIMEOUT_TRIGGERED);
-
-	/*
-	 * If this timeout already is scheduled and now is moved
-	 * earlier, reschedule it now. Otherwise leave it in place
-	 * and let it be rescheduled later.
-	 */
-	if (ISSET(new->to_flags, TIMEOUT_ONQUEUE)) {
-		if (new->to_time - ticks < old_time - ticks) {
-			CIRCQ_REMOVE(&new->to_list);
-			CIRCQ_INSERT_TAIL(&timeout_new, &new->to_list);
-		}
-		tostat.tos_readded++;
-		ret = 0;
-	} else {
-		SET(new->to_flags, TIMEOUT_ONQUEUE);
-		CIRCQ_INSERT_TAIL(&timeout_new, &new->to_list);
-	}
-#if NKCOV > 0
-	new->to_process = curproc->p_p;
-#endif
-	tostat.tos_added++;
+	timespecadd(&timeout_lastscan, &ts, &when);
+	ret = timeout_at_ts_locked(new, CLOCK_BOOTTIME, &when);
 	mtx_leave(&timeout_mutex);
 
 	return ret;
@@ -353,6 +318,49 @@ timeout_add_nsec(struct timeout *to, int nsecs)
 		to_ticks = 1;
 
 	return timeout_add(to, to_ticks);
+}
+
+int
+timeout_at_ts(struct timeout *to, clockid_t clock, const struct timespec *ts)
+{
+	int ret;
+
+	mtx_enter(&timeout_mutex);
+	ret = timeout_at_ts_locked(to, clock, ts);
+	mtx_leave(&timeout_mutex);
+
+	return ret;
+}
+
+int
+timeout_at_ts_locked(struct timeout *to, clockid_t clock,
+    const struct timespec *when)
+{
+	struct timespec old_time;
+	int ret = 1;
+
+	MUTEX_ASSERT_LOCKED(&timeout_mutex);
+	KASSERT(ISSET(to->to_flags, TIMEOUT_INITIALIZED));
+	KASSERT(timeout_clock_is_valid(clock));
+
+	old_time = to->to_time;
+	to->to_time = *when;
+	CLR(to->to_flags, TIMEOUT_TRIGGERED);
+
+	if (ISSET(to->to_flags, TIMEOUT_ONQUEUE)) {
+		if (timespeccmp(&to->to_time, &old_time, <)) {
+			CIRCQ_REMOVE(&to->to_list);
+			CIRCQ_INSERT_TAIL(&timeout_todo, &to->to_list);
+		}
+		tostat.tos_readded++;
+		ret = 0;
+	} else {
+		SET(to->to_flags, TIMEOUT_ONQUEUE);
+		CIRCQ_INSERT_TAIL(&timeout_todo, &to->to_list);
+	}
+	tostat.tos_added++;
+
+	return ret;
 }
 
 int
@@ -425,6 +433,46 @@ timeout_proc_barrier(void *arg)
 	cond_signal(c);
 }
 
+unsigned int
+timeout_maskwheel(unsigned int level, const struct timespec *abstime)
+{
+	uint32_t hi, lo;
+
+	hi = abstime->tv_sec << 7;
+	lo = abstime->tv_nsec / 7812500;
+
+	return ((hi | lo) >> (level * WHEELBITS)) & WHEELMASK;
+}
+
+unsigned int
+timeout_bucket(const struct timespec *now, const struct timespec *later)
+{
+	struct timespec diff;
+	unsigned int level;
+
+	KASSERT(timespeccmp(now, later, <));
+
+	timespecsub(later, now, &diff);
+	for (level = 0; level < nitems(timeout_level_width) - 1; level++) {
+		if (diff.tv_sec < timeout_level_width[level])
+			break;
+	}
+	return level * WHEELSIZE + timeout_maskwheel(level, later);
+}
+
+int
+timeout_clock_is_valid(clockid_t clock)
+{
+	switch (clock) {
+	case CLOCK_BOOTTIME:
+	case CLOCK_MONOTONIC:
+		return 1;
+	default:
+		break;
+	}
+	return 0;
+}
+
 /*
  * This is called from hardclock() on the primary CPU at the start of
  * every tick.
@@ -432,22 +480,48 @@ timeout_proc_barrier(void *arg)
 void
 timeout_hardclock_update(void)
 {
-	int need_softclock = 1;
+	struct timespec elapsed, now;
+	unsigned int b, done, first, last, level, need_softclock, offset;
+
+	nanouptime(&now);
 
 	mtx_enter(&timeout_mutex);
 
-	MOVEBUCKET(0, ticks);
-	if (MASKWHEEL(0, ticks) == 0) {
-		MOVEBUCKET(1, ticks);
-		if (MASKWHEEL(1, ticks) == 0) {
-			MOVEBUCKET(2, ticks);
-			if (MASKWHEEL(2, ticks) == 0)
-				MOVEBUCKET(3, ticks);
+	/*
+	 * Dump the buckets that expired while we were away.
+	 *
+	 * If the elapsed time has exceeded a level's width then we need
+	 * to dump every bucket in the level.  We have necessarily completed
+	 * a lap of that level so we need to process buckets in the next.
+	 *
+	 * Otherwise we just need to compare indices.  If the index of the
+	 * first expired bucket is greater than or equal to that of the last
+	 * then we have completed a lap of the level and need to process
+	 * buckets in the next.
+	 */
+	timespecsub(&now, &timeout_lastscan, &elapsed);
+	for (level = 0; level < nitems(timeout_level_width); level++) {
+		first = timeout_maskwheel(level, &timeout_lastscan);
+		if (elapsed.tv_sec >= timeout_level_width[level]) {
+			last = (first == 0) ? WHEELSIZE - 1 : first - 1;
+			done = 0;
+		} else {
+			last = timeout_maskwheel(level, &now);
+			done = first <= last;
 		}
+		offset = level * WHEELSIZE;
+		for (b = first;; b = (b + 1) % WHEELSIZE) {
+			CIRCQ_CONCAT(&timeout_todo, &timeout_wheel[offset + b]);
+			if (b == last)
+				break;
+		}
+		if (done)
+			break;
 	}
 
-	if (CIRCQ_EMPTY(&timeout_new) && CIRCQ_EMPTY(&timeout_todo))
-		need_softclock = 0;
+	timespecsub(&now, &tick_ts, &timeout_late);
+	timeout_lastscan = now;
+	need_softclock = !CIRCQ_EMPTY(&timeout_todo);
 
 	mtx_leave(&timeout_mutex);
 
@@ -494,9 +568,8 @@ timeout_run(struct timeout *to)
 void
 softclock(void *arg)
 {
-	struct circq *bucket;
 	struct timeout *first_new, *to;
-	int delta, needsproc, new;
+	unsigned int b, new, needsproc = 0;
 
 	first_new = NULL;
 	new = 0;
@@ -515,16 +588,16 @@ softclock(void *arg)
 		 * If due run it or defer execution to the thread,
 		 * otherwise insert it into the right bucket.
 		 */
-		delta = to->to_time - ticks;
-		if (delta > 0) {
-			bucket = &BUCKET(delta, to->to_time);
-			CIRCQ_INSERT_TAIL(bucket, &to->to_list);
+		if (timespeccmp(&timeout_lastscan, &to->to_time, <)) {
+			b = timeout_bucket(&timeout_lastscan, &to->to_time);
+			CIRCQ_INSERT_TAIL(&timeout_wheel[b], &to->to_list);
 			tostat.tos_scheduled++;
 			if (!new)
 				tostat.tos_rescheduled++;
 			continue;
 		}
-		if (!new && delta < 0)
+		if (ISSET(to->to_flags, TIMEOUT_SCHEDULED) &&
+		    timespeccmp(&to->to_time, &timeout_late, <))
 			tostat.tos_late++;
 		if (ISSET(to->to_flags, TIMEOUT_PROC)) {
 			CIRCQ_INSERT_TAIL(&timeout_proc, &to->to_list);
@@ -585,38 +658,6 @@ softclock_thread(void *arg)
 	splx(s);
 }
 
-#ifndef SMALL_KERNEL
-void
-timeout_adjust_ticks(int adj)
-{
-	struct timeout *to;
-	struct circq *p;
-	int new_ticks, b;
-
-	/* adjusting the monotonic clock backwards would be a Bad Thing */
-	if (adj <= 0)
-		return;
-
-	mtx_enter(&timeout_mutex);
-	new_ticks = ticks + adj;
-	for (b = 0; b < nitems(timeout_wheel); b++) {
-		p = CIRCQ_FIRST(&timeout_wheel[b]);
-		while (p != &timeout_wheel[b]) {
-			to = timeout_from_circq(p);
-			p = CIRCQ_FIRST(p);
-
-			/* when moving a timeout forward need to reinsert it */
-			if (to->to_time - ticks < adj)
-				to->to_time = new_ticks;
-			CIRCQ_REMOVE(&to->to_list);
-			CIRCQ_INSERT_TAIL(&timeout_todo, &to->to_list);
-		}
-	}
-	ticks = new_ticks;
-	mtx_leave(&timeout_mutex);
-}
-#endif
-
 int
 timeout_sysctl(void *oldp, size_t *oldlenp, void *newp, size_t newlen)
 {
@@ -631,10 +672,34 @@ timeout_sysctl(void *oldp, size_t *oldlenp, void *newp, size_t newlen)
 
 #ifdef DDB
 void db_show_callout_bucket(struct circq *);
+char *db_ts_str(const struct timespec *);
+
+char *
+db_ts_str(const struct timespec *ts)
+{
+	static char buf[64];
+	struct timespec tmp = *ts;
+	int neg = 0;
+
+	if (tmp.tv_sec < 0) {
+		tmp.tv_sec = -tmp.tv_sec;
+		if (tmp.tv_nsec > 0) {
+			tmp.tv_sec--;
+			tmp.tv_nsec = 1000000000 - tmp.tv_nsec;
+		}
+		neg = 1;
+	}
+
+	snprintf(buf, sizeof(buf), "%s%lld.%09ld",
+	    neg ? "-" : "", tmp.tv_sec, tmp.tv_nsec);
+
+	return buf;
+}
 
 void
 db_show_callout_bucket(struct circq *bucket)
 {
+	struct timespec left;
 	char buf[8];
 	struct timeout *to;
 	struct circq *p;
@@ -658,8 +723,9 @@ db_show_callout_bucket(struct circq *bucket)
 			    (bucket - timeout_wheel) / WHEELSIZE);
 			where = buf;
 		}
-		db_printf("%9d  %7s  0x%0*lx  %s\n",
-		    to->to_time - ticks, where, width, (ulong)to->to_arg, name);
+		timespecsub(&to->to_time, &timeout_lastscan, &left);
+		db_printf("%18s  %7s  0x%0*lx  %s\n",
+		    db_ts_str(&left), where, width, (ulong)to->to_arg, name);
 	}
 }
 
@@ -667,10 +733,11 @@ void
 db_show_callout(db_expr_t addr, int haddr, db_expr_t count, char *modif)
 {
 	int width = sizeof(long) * 2 + 2;
-	int b;
+	unsigned int b;
 
-	db_printf("ticks now: %d\n", ticks);
-	db_printf("%9s  %7s  %*s  func\n", "ticks", "wheel", width, "arg");
+	db_printf("%18s seconds up at last scan\n",
+	    db_ts_str(&timeout_lastscan));
+	db_printf("%18s  %7s  %*s  func\n", "remaining", "wheel", width, "arg");
 
 	db_show_callout_bucket(&timeout_new);
 	db_show_callout_bucket(&timeout_todo);

--- a/sys/kern/uipc_socket.c
+++ b/sys/kern/uipc_socket.c
@@ -2221,9 +2221,10 @@ so_print(void *v,
 		    (unsigned long long)so->so_sp->ssp_max);
 		(*pr)("\tssp_idletv: %lld %ld\n", so->so_sp->ssp_idletv.tv_sec,
 		    so->so_sp->ssp_idletv.tv_usec);
-		(*pr)("\tssp_idleto: %spending (@%i)\n",
+		(*pr)("\tssp_idleto: %spending (@%lld.%09ld)\n",
 		    timeout_pending(&so->so_sp->ssp_idleto) ? "" : "not ",
-		    so->so_sp->ssp_idleto.to_time);
+		    so->so_sp->ssp_idleto.to_time.tv_sec,
+		    so->so_sp->ssp_idleto.to_time.tv_nsec);
 	}
 
 	(*pr)("so_rcv:\n");

--- a/usr.sbin/trpt/trpt.c
+++ b/usr.sbin/trpt/trpt.c
@@ -1,4 +1,4 @@
-/*	$OpenBSD: trpt.c,v 1.39 2019/12/02 21:47:54 cheloha Exp $	*/
+/*	$OpenBSD: trpt.c,v 1.38 2019/11/26 15:27:09 cheloha Exp $	*/
 
 /*-
  * Copyright (c) 1997 The NetBSD Foundation, Inc.
@@ -400,8 +400,9 @@ tcp_trace(short act, short ostate, struct tcpcb *tp,
 		for (i = 0; i < TCPT_NTIMERS; i++) {
 			if (timeout_pending(&tp->t_timer[i]))
 				continue;
-			printf("%s%s=%d", cp, tcptimers[i],
-			    tp->t_timer[i].to_time);
+			printf("%s%s=%lld.%09ld", cp, tcptimers[i],
+			    (long long)tp->t_timer[i].to_time.tv_sec,
+			    tp->t_timer[i].to_time.tv_nsec);
 			if (i == TCPT_REXMT)
 				printf(" (t_rxtshft=%d)", tp->t_rxtshift);
 			cp = ", ";


### PR DESCRIPTION
***DO NOT MERGE THIS BRANCH***

re-appling following patch for OpenBSD current.

```
commit 4b4793304325522e159494e65cc0b3cd5a4dfa75
Author: cheloha <cheloha@openbsd.org>
Date:   Tue Nov 26 15:27:08 2019 +0000

    timeout(9): switch to tickless backend
```