### PR TITLE
iavf(4): multiqueue support

### DIFF
--- a/sys/dev/pci/if_iavf.c
+++ b/sys/dev/pci/if_iavf.c
@@ -717,7 +717,7 @@ static const struct iavf_aq_regs iavf_aq_regs = {
 	iavf_wr((_s), I40E_VFINT_ICR0_ENA1, I40E_VFINT_ICR0_ENA1_ADMINQ_MASK)
 
 #define iavf_nqueues(_sc)	(1 << (_sc)->sc_nqueues)
-#define iavf_allqueues(_sc)	((1 << ((_sc)->sc_nqueues+1)) - 1)
+#define iavf_allqueues(_sc)	((1 << (iavf_nqueues(_sc))) - 1)
 
 #ifdef __LP64__
 #define iavf_dmamem_hi(_ixm)	(uint32_t)(IAVF_DMA_DVA(_ixm) >> 32)

--- a/sys/dev/pci/if_iavf.c
+++ b/sys/dev/pci/if_iavf.c
@@ -62,6 +62,7 @@
 #include <sys/timeout.h>
 #include <sys/task.h>
 #include <sys/syslog.h>
+#include <sys/intrmap.h>
 
 #include <machine/bus.h>
 #include <machine/intr.h>
@@ -83,6 +84,8 @@
 #ifndef CACHE_LINE_SIZE
 #define CACHE_LINE_SIZE 64
 #endif
+
+#define IAVF_MAX_VECTORS		4
 
 #define I40E_MASK(mask, shift)		((mask) << (shift))
 #define I40E_AQ_LARGE_BUF		512
@@ -584,6 +587,7 @@ struct iavf_softc {
 	pci_intr_handle_t	 sc_ih;
 	void			*sc_ihc;
 	pcitag_t		 sc_tag;
+	struct intrmap		*sc_intrmap;
 
 	bus_dma_tag_t		 sc_dmat;
 	bus_space_tag_t		 sc_memt;
@@ -627,6 +631,7 @@ struct iavf_softc {
 	unsigned int		 sc_tx_ring_ndescs;
 	unsigned int		 sc_rx_ring_ndescs;
 	unsigned int		 sc_nqueues;	/* 1 << sc_nqueues */
+	unsigned int             sc_nintrs;
 
 	struct iavf_vector	*sc_vectors;
 
@@ -661,7 +666,7 @@ static int	iavf_add_del_addr(struct iavf_softc *, uint8_t *, int);
 static int	iavf_process_arq(struct iavf_softc *, int);
 
 static int	iavf_match(struct device *, void *, void *);
-static int	iavf_setup_interrupts(struct iavf_softc *);
+static int	iavf_setup_interrupts(struct iavf_softc *, struct pci_attach_args *);
 static void	iavf_attach(struct device *, struct device *, void *);
 
 static int	iavf_media_change(struct ifnet *);
@@ -670,6 +675,7 @@ static void	iavf_watchdog(struct ifnet *);
 static int	iavf_ioctl(struct ifnet *, u_long, caddr_t);
 static void	iavf_start(struct ifqueue *);
 static int	iavf_intr(void *);
+static int	iavf_intr_vector(void *);
 static int	iavf_up(struct iavf_softc *);
 static int	iavf_down(struct iavf_softc *);
 static int	iavf_iff(struct iavf_softc *);
@@ -733,6 +739,14 @@ static const struct iavf_aq_regs iavf_aq_regs = {
 	    I40E_VFINT_DYN_CTL0_CLEARPBA_MASK | \
 	    (IAVF_NOITR << I40E_VFINT_DYN_CTL0_ITR_INDX_SHIFT)); \
 	iavf_wr((_s), I40E_VFINT_ICR0_ENA1, I40E_VFINT_ICR0_ENA1_ADMINQ_MASK)
+#define iavf_queue_intr_enable(_s, _q)					\
+        iavf_wr((_s), I40E_VFINT_DYN_CTLN1((_q)),			\
+		I40E_VFINT_DYN_CTLN1_INTENA_MASK |			\
+		I40E_VFINT_DYN_CTLN1_CLEARPBA_MASK |			\
+		(IAVF_NOITR << I40E_VFINT_DYN_CTLN1_ITR_INDX_SHIFT))
+#define iavf_queue_intr_disable(_s, _q)					\
+        iavf_wr((_s), I40E_VFINT_DYN_CTLN1((_q)),			\
+		(IAVF_NOITR << I40E_VFINT_DYN_CTLN1_ITR_INDX_SHIFT))
 
 #define iavf_nqueues(_sc)	(1 << (_sc)->sc_nqueues)
 #define iavf_allqueues(_sc)	((1 << (iavf_nqueues(_sc))) - 1)
@@ -776,10 +790,30 @@ iavf_match(struct device *parent, void *match, void *aux)
 }
 
 static int
-iavf_setup_interrupts(struct iavf_softc *sc)
+iavf_intr_vector(void *v)
 {
-	unsigned int i, nqueues = iavf_nqueues(sc);
+	struct iavf_vector *iv = v;
+	struct iavf_softc *sc = iv->iv_sc;
+
+	struct ifnet *ifp = &sc->sc_ac.ac_if;
+	int rv = 0;
+
+	if (ISSET(ifp->if_flags, IFF_RUNNING)) {
+		rv |= iavf_rxeof(sc, iv->iv_rxr->rxr_ifiq);
+		rv |= iavf_txeof(sc, iv->iv_txr->txr_ifq);
+	}
+
+	iavf_queue_intr_enable(sc, iv->iv_qid);
+
+	return rv;
+}
+
+static int
+iavf_setup_interrupts(struct iavf_softc *sc, struct pci_attach_args *pa)
+{
+	unsigned int i, v, nqueues = iavf_nqueues(sc);
 	struct iavf_vector *iv;
+	pci_intr_handle_t ih;
 
 	sc->sc_ihc = pci_intr_establish(sc->sc_pc, sc->sc_ih,
 	    IPL_NET | IPL_MPSAFE, iavf_intr, sc, DEVNAME(sc));
@@ -804,7 +838,41 @@ iavf_setup_interrupts(struct iavf_softc *sc)
 			 DEVNAME(sc), i);
 	}
 
+	if (sc->sc_intrmap) {
+		for (i = 0; i < nqueues; i++) {
+			iv = &sc->sc_vectors[i];
+			v = i + 1; /* 0 is used for adminq */
+
+			if (pci_intr_map_msix(pa, v, &ih)) {
+				printf("%s: unable to map msi-x vector %d\n",
+				    DEVNAME(sc), v);
+				goto free_vectors;
+			}
+
+			iv->iv_ihc = pci_intr_establish_cpu(sc->sc_pc, ih,
+			    IPL_NET | IPL_MPSAFE,
+			    intrmap_cpu(sc->sc_intrmap, i),
+			    iavf_intr_vector, iv, iv->iv_name);
+			if (iv->iv_ihc == NULL) {
+				printf("%s: unable to establish interrupt %d\n",
+				    DEVNAME(sc), v);
+				goto free_vectors;
+			}
+		}
+	}
+
+	sc->sc_nintrs = nqueues + 1;
 	return 0;
+free_vectors:
+	if (sc->sc_intrmap != NULL) {
+		for (i = 0; i < nqueues; i++) {
+			struct iavf_vector *iv = &sc->sc_vectors[i];
+			if (iv->iv_ihc != NULL)
+				pci_intr_disestablish(sc->sc_pc, iv->iv_ihc);
+		}
+	}
+	free(sc->sc_vectors, M_DEVBUF, nqueues * sizeof(*sc->sc_vectors));
+	return -1;
 }
 
 void
@@ -814,7 +882,8 @@ iavf_attach(struct device *parent, struct device *self, void *aux)
 	struct ifnet *ifp = &sc->sc_ac.ac_if;
 	struct pci_attach_args *pa = aux;
 	pcireg_t memtype;
-	int tries;
+	int nmsix, tries;
+	unsigned int nqueues;
 
 	rw_init(&sc->sc_cfg_lock, "iavfcfg");
 
@@ -902,13 +971,20 @@ iavf_attach(struct device *parent, struct device *self, void *aux)
 		goto free_scratch;
 	}
 
-	if (iavf_config_irq_map(sc) != 0) {
-		printf(", timeout waiting for IRQ map response");
-		goto free_scratch;
-	}
-
 	/* msix only? */
-	if (pci_intr_map_msix(pa, 0, &sc->sc_ih) != 0) {
+	if (pci_intr_map_msix(pa, 0, &sc->sc_ih) == 0) {
+		nmsix = pci_intr_msix_count(pa);
+		if (nmsix > 1) { /* we used 1 (the 0th) for the adminq */
+			nmsix--;
+
+			sc->sc_intrmap = intrmap_create(&sc->sc_dev,
+			    nmsix, IAVF_MAX_VECTORS, INTRMAP_POWEROF2);
+			nqueues = intrmap_count(sc->sc_intrmap);
+			KASSERT(nqueues > 0);
+			KASSERT(powerof2(nqueues));
+			sc->sc_nqueues = fls(nqueues) - 1;
+		}
+	} else {
 		printf(", unable to map interrupt\n");
 		goto free_scratch;
 	}
@@ -918,12 +994,20 @@ iavf_attach(struct device *parent, struct device *self, void *aux)
 	if (memcmp(sc->sc_ac.ac_enaddr, etheranyaddr, ETHER_ADDR_LEN) == 0)
 		ether_fakeaddr(ifp);
 
-	printf(", %s, address %s\n", pci_intr_string(sc->sc_pc, sc->sc_ih),
-	    ether_sprintf(sc->sc_ac.ac_enaddr));
+	nqueues = iavf_nqueues(sc);
+	printf(", %s, %d queue%s, address %s\n",
+	       pci_intr_string(sc->sc_pc, sc->sc_ih),
+	       nqueues, (nqueues > 1 ? "s" : ""),
+	       ether_sprintf(sc->sc_ac.ac_enaddr));
 
-	if (iavf_setup_interrupts(sc) != 0) {
+	if (iavf_setup_interrupts(sc, pa) != 0) {
 		printf("%s: unable to establish interrupt handler\n",
 		    DEVNAME(sc));
+		goto free_scratch;
+	}
+
+	if (iavf_config_irq_map(sc) != 0) {
+		printf(", timeout waiting for IRQ map response");
 		goto free_scratch;
 	}
 
@@ -1225,7 +1309,6 @@ iavf_up(struct iavf_softc *sc)
 	int rv = ENOMEM;
 
 	nqueues = iavf_nqueues(sc);
-	KASSERT(nqueues == 1); /* XXX */
 
 	rw_enter_write(&sc->sc_cfg_lock);
 	if (sc->sc_dead) {
@@ -1261,6 +1344,9 @@ iavf_up(struct iavf_softc *sc)
 
 	if (iavf_queue_select(sc, IAVF_VC_OP_ENABLE_QUEUES) != 0)
 		goto down;
+
+	for (i = 0; i < nqueues; i++)
+		iavf_queue_intr_enable(sc, i);
 
 	SET(ifp->if_flags, IFF_RUNNING);
 
@@ -1442,6 +1528,8 @@ iavf_down(struct iavf_softc *sc)
 	/* make sure no hw generated work is still in flight */
 	intr_barrier(sc->sc_ihc);
 	for (i = 0; i < nqueues; i++) {
+		iavf_queue_intr_disable(sc, i);
+
 		rxr = ifp->if_iqs[i]->ifiq_softc;
 		txr = ifp->if_ifqs[i]->ifq_softc;
 
@@ -2612,25 +2700,45 @@ iavf_config_irq_map(struct iavf_softc *sc)
 	struct iavf_aq_desc iaq;
 	struct iavf_vc_vector_map *vec;
 	struct iavf_vc_irq_map_info *map;
+	struct iavf_vector *iv;
+	unsigned int num_vec = 0;
 	int tries;
 
 	memset(&iaq, 0, sizeof(iaq));
 	iaq.iaq_flags = htole16(IAVF_AQ_BUF | IAVF_AQ_RD);
 	iaq.iaq_opcode = htole16(IAVF_AQ_OP_SEND_TO_PF);
 	iaq.iaq_vc_opcode = htole32(IAVF_VC_OP_CONFIG_IRQ_MAP);
-	iaq.iaq_datalen = htole16(sizeof(*map) + sizeof(*vec));
+	iaq.iaq_datalen = htole16(sizeof(*map) + sizeof(*vec) * sc->sc_nintrs);
 	iavf_aq_dva(&iaq, IAVF_DMA_DVA(&sc->sc_scratch));
 
 	map = IAVF_DMA_KVA(&sc->sc_scratch);
-	map->num_vectors = htole16(1);
 
 	vec = map->vecmap;
-	vec[0].vsi_id = htole16(sc->sc_vsi_id);
-	vec[0].vector_id = 0;
-	vec[0].rxq_map = htole16(iavf_allqueues(sc));
-	vec[0].txq_map = htole16(iavf_allqueues(sc));
-	vec[0].rxitr_idx = htole16(IAVF_NOITR);
-	vec[0].txitr_idx = htole16(IAVF_NOITR);
+	if (sc->sc_nintrs == 1) {
+		vec[num_vec].vsi_id = htole16(sc->sc_vsi_id);
+		vec[num_vec].vector_id = htole16(num_vec);
+		vec[num_vec].rxq_map = htole16(iavf_allqueues(sc));
+		vec[num_vec].txq_map = htole16(iavf_allqueues(sc));
+		vec[num_vec].rxitr_idx = htole16(IAVF_NOITR);
+		vec[num_vec].txitr_idx = htole16(IAVF_NOITR);
+		num_vec++;
+	} else if (sc->sc_nintrs > 1) {
+		for (; num_vec < sc->sc_nintrs - 1; num_vec++) {
+			iv = &sc->sc_vectors[num_vec];
+			vec[num_vec].vsi_id = htole16(sc->sc_vsi_id);
+			vec[num_vec].vector_id = htole16(num_vec + 1);
+			vec[num_vec].rxq_map = htole16(1 << iv->iv_qid);
+			vec[num_vec].txq_map = htole16(1 << iv->iv_qid);
+			vec[num_vec].rxitr_idx = htole16(IAVF_ITR0);
+			vec[num_vec].txitr_idx = htole16(IAVF_ITR1);
+		}
+		vec[num_vec].vsi_id = htole16(sc->sc_vsi_id);
+		vec[num_vec].vector_id = htole16(0);
+		vec[num_vec].rxq_map = htole16(0);
+		vec[num_vec].txq_map = htole16(0);
+		num_vec++;
+	}
+	map->num_vectors = htole16(num_vec);
 
 	bus_dmamap_sync(sc->sc_dmat, IAVF_DMA_MAP(&sc->sc_scratch), 0, IAVF_DMA_LEN(&sc->sc_scratch),
 	    BUS_DMASYNC_PREREAD);


### PR DESCRIPTION
iavf(4) multiqueue support.
Since the ESXi PF driver doesn't allow a single queue driver, OpenBSD iavf(4) doesn't work as follows.

```
iavf1 at pci11 dev 0 function 0 "Intel XL710/X710 VF" rev 0x01, VF version 1.1, VF 0 VSI 19config irq map failed: -5
, msix, address 00:0c:29:a2:be:07
```

This message shows that the IRQ mapping request results in an error code -5 (IAVF_VC_RC_ERR_PARAM).
The 'iavf_config_irq_map' function sets one IRQ for the admin queue and tx/rx queue. This is a different
number of queues from the msix interrupt counts.

The Linux PF driver allows a single queue driver, so this won't be a problem.