### PR TITLE
lldb: fix reading stack pointer and frame pointer in the pcb.

### DIFF
--- a/gnu/llvm/lldb/source/Plugins/Process/OpenBSDKernel/RegisterContextOpenBSDKernel_arm64.cpp
+++ b/gnu/llvm/lldb/source/Plugins/Process/OpenBSDKernel/RegisterContextOpenBSDKernel_arm64.cpp
@@ -91,7 +91,7 @@ bool RegisterContextOpenBSDKernel_arm64::ReadRegister(
     value = (u_int64_t)sf.sf_x29;
     return true;
   case gpr_sp_arm64:
-    value = (u_int64_t)pcb.pcb_sp;
+    value = (u_int64_t)(pcb.pcb_sp + sizeof(sf));
     return true;
   case gpr_pc_arm64:
     value = (u_int64_t)sf.sf_lr;

--- a/gnu/llvm/lldb/source/Plugins/Process/OpenBSDKernel/RegisterContextOpenBSDKernel_i386.cpp
+++ b/gnu/llvm/lldb/source/Plugins/Process/OpenBSDKernel/RegisterContextOpenBSDKernel_i386.cpp
@@ -62,12 +62,13 @@ bool RegisterContextOpenBSDKernel_i386::ReadRegister(
   if ((pcb.pcb_flags & PCB_SAVECTX) != 0) {
     uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
     switch (reg) {
-#define PCBREG(x)							\
-    case lldb_##x##_i386:						\
-      value = pcb.pcb_##x;						\
+    case lldb_esp_i386:
+      value = (u_int32_t)pcb.pcb_ebp;
       return true;
-    PCBREG(ebp);
-    PCBREG(esp);
+    case lldb_ebp_i386:
+      value = m_thread.GetProcess()->ReadPointerFromMemory(pcb.pcb_ebp,
+							   error);
+      return true;
     case lldb_eip_i386:
       value = m_thread.GetProcess()->ReadPointerFromMemory(pcb.pcb_ebp + 4,
 							   error);
@@ -88,17 +89,21 @@ bool RegisterContextOpenBSDKernel_i386::ReadRegister(
 
   uint32_t reg = reg_info->kinds[lldb::eRegisterKindLLDB];
   switch (reg) {
+#define PCBREG(x, offset)						\
+    case lldb_##x##_i386:						\
+      value = (u_int32_t)(pcb.pcb_##x + (offset));			\
+      return true;
 #define SFREG(x)							\
     case lldb_##x##_i386:						\
-      value = sf.sf_##x;						\
+      value = (u_int32_t)sf.sf_##x;					\
       return true;
 
     SFREG(edi);
     SFREG(esi);
     SFREG(ebx);
     SFREG(eip);
-    PCBREG(ebp);
-    PCBREG(esp);
+    PCBREG(ebp, 0);
+    PCBREG(esp, sizeof(sf));
   }
 #endif
   return false;

--- a/gnu/llvm/lldb/source/Plugins/Process/OpenBSDKernel/RegisterContextOpenBSDKernel_x86_64.cpp
+++ b/gnu/llvm/lldb/source/Plugins/Process/OpenBSDKernel/RegisterContextOpenBSDKernel_x86_64.cpp
@@ -79,7 +79,7 @@ bool RegisterContextOpenBSDKernel_x86_64::ReadRegister(
       return true;
 #define PCBREG(x, offset)			\
     case lldb_##x##_x86_64:			\
-      value = pcb.pcb_##x + offset;		\
+      value = pcb.pcb_##x + (offset);		\
       return true;
     switch (reg) {
       SFREG(r15);

--- a/gnu/llvm/lldb/source/Plugins/Process/OpenBSDKernel/RegisterContextOpenBSDKernel_x86_64.cpp
+++ b/gnu/llvm/lldb/source/Plugins/Process/OpenBSDKernel/RegisterContextOpenBSDKernel_x86_64.cpp
@@ -77,9 +77,9 @@ bool RegisterContextOpenBSDKernel_x86_64::ReadRegister(
     case lldb_##x##_x86_64:			\
       value = (u_int64_t)sf.sf_##x;		\
       return true;
-#define PCBREG(x)				\
+#define PCBREG(x, offset)			\
     case lldb_##x##_x86_64:			\
-      value = pcb.pcb_##x;			\
+      value = pcb.pcb_##x + offset;		\
       return true;
     switch (reg) {
       SFREG(r15);
@@ -89,14 +89,14 @@ bool RegisterContextOpenBSDKernel_x86_64::ReadRegister(
       SFREG(rbp);
       SFREG(rbx);
       SFREG(rip);
-      PCBREG(rsp);
+      PCBREG(rsp, sizeof(sf));
     }
   } else {
     switch (reg) {
-      PCBREG(rbp);
-      PCBREG(rsp);
+      PCBREG(rbp, 0);
+      PCBREG(rsp, 8);
     case lldb_rip_x86_64:
-      value = m_thread.GetProcess()->ReadPointerFromMemory(pcb.pcb_rbp + 8,
+      value = m_thread.GetProcess()->ReadPointerFromMemory(pcb.pcb_rsp,
 							   error);
       return true;
     }


### PR DESCRIPTION
Keep consistent with the gdb way.